### PR TITLE
Add 5 Chinese platform templates (WeChat, Zhihu, Xiaohongshu, Bilibili, Chinese News)

### DIFF
--- a/templates/bilibili-video-clipper.json
+++ b/templates/bilibili-video-clipper.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "Bilibili Video (B站视频)",
+  "behavior": "create",
+  "noteNameFormat": "{{date|date:\"YYYY-MM-DD\"}} {{title|replace:\"_哔哩哔哩_bilibili\":\"\"|safe_name}}",
+  "path": "Clippings/Videos",
+  "noteContentFormat": "## {{title|replace:\"_哔哩哔哩_bilibili\":\"\"}}\n\n<iframe src=\"https://player.bilibili.com/player.html?bvid={{url|replace:\"https://www.bilibili.com/video/\":\"\"|split:\"/\"|first|split:\"?\"|first}}&high_quality=1&quality=80&autoplay=0\" width=\"100%\" height=\"500\" frameborder=\"0\" allowfullscreen></iframe>\n\n> Channel: {{meta:name:author}} | Saved: {{date|date:\"YYYY-MM-DD\"}} | [Open on Bilibili]({{url}})\n\n---\n\n## Notes\n\n{{selection}}\n\n{{highlights}}",
+  "properties": [
+    { "name": "title",   "value": "{{title|replace:\"_哔哩哔哩_bilibili\":\"\"}}",  "type": "text" },
+    { "name": "source",  "value": "{{url}}",                "type": "text" },
+    { "name": "channel", "value": "{{meta:name:author}}",   "type": "text" },
+    { "name": "saved",   "value": "{{date}}",               "type": "date" },
+    { "name": "type",    "value": "video",                  "type": "text" },
+    { "name": "tags",    "value": "video, bilibili",        "type": "multitext" }
+  ],
+  "triggers": [
+    "*.bilibili.com"
+  ]
+}

--- a/templates/chinese-news-article-clipper.json
+++ b/templates/chinese-news-article-clipper.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "Chinese News & Tech Articles (中文资讯)",
+  "behavior": "create",
+  "noteNameFormat": "{{date|date:\"YYYY-MM-DD\"}} {{title|safe_name}}",
+  "path": "Clippings",
+  "noteContentFormat": "## {{title}}\n\n> Author: {{author}} | Source: [{{site}}]({{url}}) | {{published|date:\"YYYY-MM-DD\"}}\n\n{{content}}\n\n---\n\n## Highlights\n\n{{selection}}\n\n{{highlights}}",
+  "properties": [
+    { "name": "title",     "value": "{{title}}",                         "type": "text" },
+    { "name": "source",    "value": "{{url}}",                           "type": "text" },
+    { "name": "author",    "value": "{{author}}",                        "type": "text" },
+    { "name": "published", "value": "{{published|date:\"YYYY-MM-DD\"}}", "type": "date" },
+    { "name": "saved",     "value": "{{date}}",                          "type": "date" },
+    { "name": "type",      "value": "article",                           "type": "text" },
+    { "name": "tags",      "value": "clipping",                          "type": "multitext" }
+  ],
+  "triggers": [
+    "*.wsj.com",
+    "cn.wsj.com",
+    "caixin.com",
+    "*.sspai.com",
+    "36kr.com",
+    "huxiu.com",
+    "ifanr.com",
+    "*.lifeweek.com.cn",
+    "*.v2ex.com",
+    "okjike.com",
+    "*.jike.com"
+  ]
+}

--- a/templates/wechat-article-clipper.json
+++ b/templates/wechat-article-clipper.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "WeChat Article (微信公众号)",
+  "behavior": "create",
+  "noteNameFormat": "{{date|date:\"YYYY-MM-DD\"}} {{title|safe_name}}",
+  "path": "Clippings",
+  "noteContentFormat": "## {{title}}\n\n> Author: {{meta:property:og:article:author}} | Source: [WeChat]({{url}})\n\n{{selectorHtml:#js_content|markdown}}\n\n---\n\n## Highlights\n\n{{selection}}\n\n{{highlights}}",
+  "properties": [
+    { "name": "title",  "value": "{{title}}",                           "type": "text" },
+    { "name": "source", "value": "{{url}}",                             "type": "text" },
+    { "name": "author", "value": "{{meta:property:og:article:author}}", "type": "text" },
+    { "name": "saved",  "value": "{{date}}",                            "type": "date" },
+    { "name": "type",   "value": "article",                             "type": "text" },
+    { "name": "tags",   "value": "clipping, wechat",                    "type": "multitext" }
+  ],
+  "triggers": [
+    "mp.weixin.qq.com"
+  ]
+}

--- a/templates/xiaohongshu-clipper.json
+++ b/templates/xiaohongshu-clipper.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "Xiaohongshu / RedNote (小红书)",
+  "behavior": "create",
+  "noteNameFormat": "{{date|date:\"YYYY-MM-DD\"}} {{title|safe_name}}",
+  "path": "Clippings",
+  "noteContentFormat": "## {{title}}\n\n> Author: {{author}} | Source: [Xiaohongshu]({{url}})\n\n### Images\n\n![]({{selector:.swiper-slide:not(.swiper-slide-duplicate) img?src|unique|join:\")\n\n![](\"}})\n\n### Content\n\n{{selectorHtml:#detail-desc|markdown}}\n\n---\n\n> [View original]({{url}})\n\n---\n\n## Highlights\n\n{{selection}}\n\n{{highlights}}",
+  "properties": [
+    { "name": "title",  "value": "{{title}}",  "type": "text" },
+    { "name": "source", "value": "{{url}}",    "type": "text" },
+    { "name": "author", "value": "{{author}}", "type": "text" },
+    { "name": "saved",  "value": "{{date}}",   "type": "date" },
+    { "name": "type",   "value": "note",       "type": "text" },
+    { "name": "tags",   "value": "clipping, xiaohongshu", "type": "multitext" }
+  ],
+  "triggers": [
+    "www.xiaohongshu.com",
+    "xhslink.com"
+  ]
+}

--- a/templates/zhihu-clipper.json
+++ b/templates/zhihu-clipper.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "Zhihu (知乎)",
+  "behavior": "create",
+  "noteNameFormat": "{{date|date:\"YYYY-MM-DD\"}} {{title|safe_name}}",
+  "path": "Clippings",
+  "noteContentFormat": "## {{title}}\n\n> Author: {{author}} | Source: [Zhihu]({{url}})\n\n{{selectorHtml:.RichText|markdown}}\n\n---\n\n## Highlights\n\n{{selection}}\n\n{{highlights}}",
+  "properties": [
+    { "name": "title",  "value": "{{title}}",  "type": "text" },
+    { "name": "source", "value": "{{url}}",    "type": "text" },
+    { "name": "author", "value": "{{author}}", "type": "text" },
+    { "name": "saved",  "value": "{{date}}",   "type": "date" },
+    { "name": "type",   "value": "article",    "type": "text" },
+    { "name": "tags",   "value": "clipping, zhihu", "type": "multitext" }
+  ],
+  "triggers": [
+    "www.zhihu.com/question",
+    "zhuanlan.zhihu.com"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds web clipper templates for **5 major Chinese content platforms** — the first Chinese-language platform templates in this repo.

| Template | Platform | Key Feature |
|----------|----------|-------------|
| **WeChat Article** | mp.weixin.qq.com | `#js_content` selector for clean article extraction |
| **Zhihu** | zhihu.com (Q&A + columns) | `.RichText` selector filters out votes, comments, recommendations |
| **Xiaohongshu / RedNote** | xiaohongshu.com | Carousel image dedup: `:not(.swiper-slide-duplicate)` + `unique` filter |
| **Bilibili** | bilibili.com | Auto-extracts BV number from URL for iframe embed; strips `_哔哩哔哩_bilibili` title suffix |
| **Chinese News & Tech** | WSJ CN, Caixin, SSPAI, 36Kr, Huxiu, V2EX, Jike, etc. | Multi-site catch-all for Chinese tech/news articles |

## Technical highlights

- **Xiaohongshu image deduplication**: XHS uses Swiper.js carousel that duplicates slides for infinite loop. The template uses CSS pseudo-class \`:not(.swiper-slide-duplicate)\` combined with the \`unique\` filter and a \`join\` trick to produce clean, deduplicated image embeds.
- **Bilibili BV extraction**: Chained filters extract the BV number from any Bilibili URL format for iframe embedding.
- **WeChat \`#js_content\`**: Targets the exact content container, avoiding recommended articles and UI chrome.
- **Zhihu \`.RichText\`**: Grabs only the answer/article body, skipping vote counts, comment sections, and sidebar content.

## Test plan

- [x] Tested on WeChat articles (mp.weixin.qq.com)
- [x] Tested on Zhihu answers and columns (zhihu.com)
- [x] Tested on Xiaohongshu notes with single and multiple images
- [x] Tested on Bilibili video pages (BV number extraction + iframe)
- [x] Tested on 36Kr, SSPAI, V2EX articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)