### PR TITLE
Fix readme's import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This is a community collection of templates for the official [Obsidian Web Clipp
 1) Install the Obsidian Web Clipper extension (Chrome/Firefox/Safari).
 2) Copy JSON from this repo’s `templates/`
 3) In the extension, open Templates → “New Template”.
-  This creates a new blank template in your list.
+   - This creates a new blank template in your list.
 4) Click on "Import" and Paste the JSON into the text field and click on "Import".
-  This will create an additional imported template entry in the list, named from the JSON import, BELOW your "New template" draft.
+   - This will create an additional imported template entry in the list, named from the JSON import, BELOW your "New template" draft.
 5) Drag the new JSON imported template below the Default template.
-  Note: the first entry in the template list is the default.
+   - Note: the first entry in the template list is the default.
 6) Delete the blank "New Template"
    a) Make sure the blank template created in step 3 is selected
    b) Click on "More > Delete" at the top of the "Edit Template" page

--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ This is a community collection of templates for the official [Obsidian Web Clipp
 1) Install the Obsidian Web Clipper extension (Chrome/Firefox/Safari).
 2) Copy JSON from this repo’s `templates/`
 3) In the extension, open Templates → “New Template”.
-4) Click on "Import" and Paste the JSO into the text field and click on "Import".
-5) Visit a matching site (per the template’s “triggers”), then clip using that template.
+  This creates a new blank template in your list.
+4) Click on "Import" and Paste the JSON into the text field and click on "Import".
+  This will create an additional imported template entry in the list, named from the JSON import, BELOW your "New template" draft.
+5) Drag the new JSON imported template below the Default template.
+  Note: the first entry in the template list is the default.
+6) Delete the blank "New Template"
+   a) Make sure the blank template created in step 3 is selected
+   b) Click on "More > Delete" at the top of the "Edit Template" page
+7) Visit a matching site (per the template’s “triggers”), then clip using that template.
 
 Tip: Validate your JSON before saving:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This is a community collection of templates for the official [Obsidian Web Clipp
 5) Drag the new JSON imported template below the Default template.
    - Note: the first entry in the template list is the default.
 6) Delete the blank "New Template"
-   a) Make sure the blank template created in step 3 is selected
-   b) Click on "More > Delete" at the top of the "Edit Template" page
+   1) Make sure the blank template created in step 3 is selected.
+   2) Click on "More > Delete" at the top of the "Edit Template" page
 7) Visit a matching site (per the template’s “triggers”), then clip using that template.
 
 Tip: Validate your JSON before saving:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ This is a community collection of templates for the official [Obsidian Web Clipp
 ## Quick start
 
 1) Install the Obsidian Web Clipper extension (Chrome/Firefox/Safari).
-2) In the extension, open Templates → “New Template”.
-3) Copy JSON from this repo’s `templates/` and paste into your template.
-4) Visit a matching site (per the template’s “triggers”), then clip using that template.
+2) Copy JSON from this repo’s `templates/`
+3) In the extension, open Templates → “New Template”.
+4) Click on "Import" and Paste the JSO into the text field and click on "Import".
+5) Visit a matching site (per the template’s “triggers”), then clip using that template.
 
 Tip: Validate your JSON before saving:
 


### PR DESCRIPTION
Add a method to import the copied JSON code into a new template - which creates a second template, and clean up the temporary template.